### PR TITLE
fix a little bug in demo_node.cpp to show the map correctly

### DIFF
--- a/grid_path_searcher/src/demo_node.cpp
+++ b/grid_path_searcher/src/demo_node.cpp
@@ -90,7 +90,7 @@ void rcvPointCloudCallBack(const sensor_msgs::PointCloud2 &pointcloud_map)
 
     pcl::toROSMsg(cloud_vis, map_vis);
 
-    map_vis.header.frame_id = "/world";
+    map_vis.header.frame_id = "world";
     _grid_map_vis_pub.publish(map_vis);
 
     _has_map = true;


### PR DESCRIPTION
I found  there are a little bug in the demo_node.cpp, the 93 line frame_id is "/world", it makes we have to set the reference map in rviz as "//world" (and it can't pre-set at the rviz config) , so I fix the problem, hope you could allow my PR, thanks!